### PR TITLE
Minor Changes

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -136,7 +136,11 @@ GPERFTOOLS_VERSION=2.0-p1 $SOURCE_DIR/source/gperftools/build.sh
 # Build glog
 ################################################################################
 GFLAGS_VERSION=2.0 GLOG_VERSION=0.3.2-p1 $SOURCE_DIR/source/glog/build.sh
-GFLAGS_VERSION=2.0 GLOG_VERSION=0.3.3-p1 $SOURCE_DIR/source/glog/build.sh
+
+if [[ ! "$RELEASE_NAME" =~ CentOS.*5\.[[:digit:]] ]]; then
+  # CentOS 5 has issues with the glog patch, probably autotools is too old.
+  GFLAGS_VERSION=2.0 GLOG_VERSION=0.3.3-p1 $SOURCE_DIR/source/glog/build.sh
+fi
 
 ################################################################################
 # Build gtest

--- a/source/googletest/build.sh
+++ b/source/googletest/build.sh
@@ -36,7 +36,7 @@ if needs_build_package ; then
   pushd ..
   mkdir -p build-googletest-$GOOGLETEST_VERSION
   pushd build-googletest-$GOOGLETEST_VERSION
-  wrap cmake -DCMAKE_CXX_FLAGS=$CXXFLAGS -DCMAKE_INSTALL_PREFIX=$LOCAL_INSTALL ../googletest-$GOOGLETEST_VERSION
+  wrap cmake -DCMAKE_CXX_FLAGS="${CXXFLAGS}" -DCMAKE_INSTALL_PREFIX=$LOCAL_INSTALL ../googletest-$GOOGLETEST_VERSION
   wrap make -j${BUILD_THREADS:-4}
   wrap make install
 


### PR DESCRIPTION
Making sure the static version of gmock can be linked dynamically and glog-0.3.3-p1 is not build on CentOS 5.