### PR TITLE
Disable Thrift c_glib due to compilation error

### DIFF
--- a/source/thrift/build.sh
+++ b/source/thrift/build.sh
@@ -48,8 +48,10 @@ if needs_build_package ; then
   if [ -d "${PIC_LIB_PATH:-}" ]; then
     PIC_LIB_OPTIONS="--with-zlib=${PIC_LIB_PATH} "
   fi
+
   JAVA_PREFIX=${LOCAL_INSTALL}/java PY_PREFIX=${LOCAL_INSTALL}/python \
     wrap ./configure --with-pic --prefix=${LOCAL_INSTALL} \
+    --with-c_glib=no \
     --with-php=no --with-java=no --with-perl=no --with-erlang=no --with-csharp=no \
     --with-ruby=no --with-haskell=no --with-erlang=no --with-d=no \
     --with-boost=${BOOST_ROOT} \


### PR DESCRIPTION
See the commit message. If you are able to reproduce this and resolve it in some other way let me know