### PR TITLE
Add llvm-3.3-no-asserts target

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -65,8 +65,9 @@ fi
 # LLVM
 ################################################################################
 
-# Build Default LLVM
+# Build Default LLVM with and without asserts
 LLVM_VERSION=3.3-p1 $SOURCE_DIR/source/llvm/build.sh
+LLVM_VERSION=3.3-no-asserts-p1 $SOURCE_DIR/source/llvm/build.sh
 
 # CentOS 5 can't build trunk LLVM due to missing perf counter
 if [[ ! "$RELEASE_NAME" =~ CentOS.*5\.[[:digit:]] ]]; then


### PR DESCRIPTION
The new target simply builds llvm 3.3 with assertions disabled, which
offers improved performance for release builds, compared with the
current llvm build that is in release mode with assertions. This
required some changes to helper functions, since the current code
assumes that you only build one version of each source tarball.

I tested this locally to confirm that all packages could be built.