### PR TITLE
Prepare to move automated toolchain builds to a new environment

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -372,11 +372,9 @@ function build_dist_package() {
       -DrepositoryId=cdh.releases.repo -Dpackaging=tar.gz -Dclassifier=${label} || $RET_VAL
 
     # Publish to S3 as well
-    if [[ -n "${AWS_ACCESS_KEY_ID}" && -n "${AWS_SECRET_ACCESS_KEY}" && -n "${S3_BUCKET}" ]]; then
-      aws s3 cp "${BUILD_DIR}/${FULL_TAR_NAME}.tar.gz" \
-        s3://${S3_BUCKET}/build/${TOOLCHAIN_BUILD_ID}/${PACKAGE}/${PACKAGE_VERSION}${PATCH_VERSION}-${COMPILER}-${COMPILER_VERSION}/${FULL_TAR_NAME}-${label}.tar.gz \
-        --region=us-west-1 || $RET_VAL
-    fi
+    aws s3 cp "${BUILD_DIR}/${FULL_TAR_NAME}.tar.gz" \
+      s3://${S3_BUCKET}/build/${TOOLCHAIN_BUILD_ID}/${PACKAGE}/${PACKAGE_VERSION}${PATCH_VERSION}-${COMPILER}-${COMPILER_VERSION}/${FULL_TAR_NAME}-${label}.tar.gz \
+      --region=us-west-1 || $RET_VAL
 
   fi
 }


### PR DESCRIPTION
This change updates the build scripts so that builds can take
advantage of preconfigured Amazon EC2 VM instances, where S3
credentials can be supplied by IAM roles instead of environment
variables.

Consequently, the credential checking logic before the S3 upload
is removed from functions.sh, where the binary artifacts are copied
to S3 using AWSCLI. AWSCLI will attempt to authenticate anyway,
and the script already has logic to decide whether an upload failure
should fail the whole build process. This means that there is no real
value in performing a similar check in the script at the same
location.

Change-Id: I08d26206e33aa142b8c166aefe21ac1315fdbd3a
(cherry picked from commit f1be72c38f94962e88836550c51ac95c0c1e49c3)