### PR TITLE
Prepare to move automated toolchain builds to a new environment

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -39,7 +39,7 @@ function popd() {
   command popd > /dev/null
 }
 
-# Downloads a given package from S3, aruments to this function are the package and
+# Downloads a given package from S3, arguments to this function are the package and
 # package-filename and the target download folder
 function download_dependency() {
   # S3 Base URL
@@ -376,12 +376,9 @@ function build_dist_package() {
       -DrepositoryId=cdh.releases.repo -Dpackaging=tar.gz -Dclassifier=${BUILD_LABEL} || $RET_VAL
 
     # Publish to S3 as well
-    if [[ -n "${AWS_ACCESS_KEY_ID}" && -n "${AWS_SECRET_ACCESS_KEY}" && -n "${S3_BUCKET}" ]]; then
-      aws s3 cp "${BUILD_DIR}/${FULL_TAR_NAME}.tar.gz" \
-        s3://${S3_BUCKET}/build/${TOOLCHAIN_BUILD_ID}/${PACKAGE}/${PACKAGE_VERSION}${PATCH_VERSION}-${COMPILER}-${COMPILER_VERSION}/${FULL_TAR_NAME}-${BUILD_LABEL}.tar.gz \
-        --region=us-west-1 || $RET_VAL
-    fi
-
+    aws s3 cp "${BUILD_DIR}/${FULL_TAR_NAME}.tar.gz" \
+      s3://${S3_BUCKET}/build/${TOOLCHAIN_BUILD_ID}/${PACKAGE}/${PACKAGE_VERSION}${PATCH_VERSION}-${COMPILER}-${COMPILER_VERSION}/${FULL_TAR_NAME}-${BUILD_LABEL}.tar.gz \
+      --region=us-west-1 || $RET_VAL
   fi
 }
 

--- a/init-compiler.sh
+++ b/init-compiler.sh
@@ -30,7 +30,7 @@ set -o pipefail
 
 if [[ "$OSTYPE" =~ ^linux ]]; then
   # ARCH_FLAGS are used to convey architectur dependent flags that should
-  # be obbeyed by libraries explicitly needing this information.
+  # be obeyed by libraries explicitly needing this information.
   if [[ "$ARCH_NAME" == "ppc64le" ]]; then
      ARCH_FLAGS="-mvsx -maltivec"
   else

--- a/init.sh
+++ b/init.sh
@@ -105,7 +105,7 @@ export AUTOMAKE_VERSION
 : ${LIBTOOL_VERSION=2.4.2}
 export LIBTOOL_VERSION
 
-# Set the build label from the Jenkins envirment if it was not already set, or fall
+# Set the build label from the Jenkins environment if it was not already set, or fall
 # back to 'generic'.
 : ${label="generic"}
 : ${BUILD_LABEL=$label}


### PR DESCRIPTION
This change updates the build scripts so that builds can take
advantage of preconfigured Amazon EC2 VM instances, where S3
credentials can be supplied by IAM roles instead of environment
variables.

Consequently, the credential checking logic before the S3 upload
is removed from functions.sh, where the binary artifacts are copied
to S3 using AWSCLI. AWSCLI will attempt to authenticate anyway,
and the script already has logic to decide whether an upload failure
should fail the whole build process, so there is no real value in
performing a similar check in the script at the same location.

There are also a couple of typos fixed in various comments.

Change-Id: I08d26206e33aa142b8c166aefe21ac1315fdbd3a
(cherry picked from commit 981e1b0fd6fd1308f6e24ce138edfeede8652c5a)