### PR TITLE
IMPALA-10088 Fix DeadLock while run unifiedbetests on aarch64 platform

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -210,7 +210,7 @@ if (( BUILD_HISTORICAL )); then
   GPERFTOOLS_VERSION=2.3 $SOURCE_DIR/source/gperftools/build.sh
 fi
 # IMPALA-6414: Required until issues with 2.6.3 have been sorted out.
-GPERFTOOLS_VERSION=2.5-p1 $SOURCE_DIR/source/gperftools/build.sh
+GPERFTOOLS_VERSION=2.5-p2 $SOURCE_DIR/source/gperftools/build.sh
 GPERFTOOLS_VERSION=2.6.3 $SOURCE_DIR/source/gperftools/build.sh
 
 ################################################################################

--- a/source/gperftools/gperftools-2.5-patches/0002-Port-gperftools-to-adapt-aarch64.patch
+++ b/source/gperftools/gperftools-2.5-patches/0002-Port-gperftools-to-adapt-aarch64.patch
@@ -1,0 +1,239 @@
+From 04d2ac9ff7f0b4e0432aff16cd463f5c4d6f8b0a Mon Sep 17 00:00:00 2001
+From: zhaorenhai <zhaorenhai@hotmail.com>
+Date: Thu, 13 Aug 2020 18:58:17 +0800
+Subject: [PATCH] add aarch64 stacktrace implementation
+
+---
+ src/stacktrace.cc          |  15 ++++
+ src/stacktrace_arm64-inl.h | 172 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 187 insertions(+)
+ create mode 100644 src/stacktrace_arm64-inl.h
+
+diff --git a/src/stacktrace.cc b/src/stacktrace.cc
+index 395d569..9c9aeef 100644
+--- a/src/stacktrace.cc
++++ b/src/stacktrace.cc
+@@ -161,6 +161,15 @@ struct GetStackImplementation {
+ #define HAVE_GST_win32
+ #endif
+ 
++#if defined(__aarch64__)
++#define STACKTRACE_INL_HEADER "stacktrace_arm64-inl.h"
++#define GST_SUFFIX arm64
++#include "stacktrace_impl_setup-inl.h"
++#undef GST_SUFFIX
++#undef STACKTRACE_INL_HEADER
++#define HAVE_GST_arm64
++#endif
++
+ static GetStackImplementation *all_impls[] = {
+ #ifdef HAVE_GST_libgcc
+   &impl__libgcc,
+@@ -185,6 +194,9 @@ static GetStackImplementation *all_impls[] = {
+ #endif
+ #ifdef HAVE_GST_win32
+   &impl__win32,
++#endif
++#ifdef HAVE_GST_arm64
++  &impl__arm64,
+ #endif
+   NULL
+ };
+@@ -203,6 +215,8 @@ static bool get_stack_impl_inited;
+ static GetStackImplementation *get_stack_impl = &impl__instrument;
+ #elif defined(HAVE_GST_win32)
+ static GetStackImplementation *get_stack_impl = &impl__win32;
++#elif defined(HAVE_GST_arm64)
++static GetStackImplementation *get_stack_impl = &impl__arm64;
+ #elif defined(HAVE_GST_x86) && defined(TCMALLOC_DONT_PREFER_LIBUNWIND)
+ static GetStackImplementation *get_stack_impl = &impl__x86;
+ #elif defined(HAVE_GST_ppc) && defined(TCMALLOC_DONT_PREFER_LIBUNWIND)
+@@ -218,6 +232,7 @@ static GetStackImplementation *get_stack_impl = &impl__arm;
+ #elif 0
+ // This is for the benefit of code analysis tools that may have
+ // trouble with the computed #include above.
++# include "straktrace_arm64-inl.h"
+ # include "stacktrace_x86-inl.h"
+ # include "stacktrace_libunwind-inl.h"
+ # include "stacktrace_generic-inl.h"
+diff --git a/src/stacktrace_arm64-inl.h b/src/stacktrace_arm64-inl.h
+new file mode 100644
+index 0000000..2a32e88
+--- /dev/null
++++ b/src/stacktrace_arm64-inl.h
+@@ -0,0 +1,172 @@
++#ifndef BASE_STACKTRACE_ARM64_INL_H_
++#define BASE_STACKTRACE_ARM64_INL_H_
++// Note: this file is included into stacktrace.cc more than once.
++// Anything that should only be defined once should be here:
++#include <sys/mman.h>
++#include <unistd.h>
++#include <gperftools/stacktrace.h>
++#include <base/vdso_support.h>
++#include <ucontext.h>
++#include <atomic>
++#include <cassert>
++#include <cstdint>
++#include <iostream>
++
++#if __has_attribute(no_sanitize_address)
++#define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
++#else
++#define ATTRIBUTE_NO_SANITIZE_ADDRESS
++#endif
++
++#if __has_attribute(no_sanitize_memory)
++#define ATTRIBUTE_NO_SANITIZE_MEMORY __attribute__((no_sanitize_memory))
++#else
++#define ATTRIBUTE_NO_SANITIZE_MEMORY
++#endif
++
++static const uintptr_t kUnknownFrameSize = 0;
++
++#if defined(__linux__)
++// Returns the address of the VDSO __kernel_rt_sigreturn function, if present.
++static const unsigned char* GetKernelRtSigreturnAddress() {
++  constexpr uintptr_t kImpossibleAddress = 1;
++  static std::atomic<uintptr_t> memoized{kImpossibleAddress};
++  uintptr_t address = memoized.load(std::memory_order_relaxed);
++  if (address != kImpossibleAddress) {
++    return reinterpret_cast<const unsigned char*>(address);
++  }
++
++  address = reinterpret_cast<uintptr_t>(nullptr);
++
++#ifdef HAVE_VDSO_SUPPORT
++  base::VDSOSupport vdso;
++  if (vdso.IsPresent()) {
++    base::VDSOSupport::SymbolInfo symbol_info;
++    if (!vdso.LookupSymbol("__kernel_rt_sigreturn", "LINUX_2.6.39", STT_FUNC,
++                           &symbol_info) ||
++        symbol_info.address == nullptr) {
++      // Unexpected: VDSO is present, yet the expected symbol is missing
++      // or null.
++      assert(false && "VDSO is present, but doesn't have expected symbol");
++    } else {
++      if (reinterpret_cast<uintptr_t>(symbol_info.address) !=
++          kImpossibleAddress) {
++        address = reinterpret_cast<uintptr_t>(symbol_info.address);
++      } else {
++        assert(false && "VDSO returned invalid address");
++      }
++    }
++  }
++#endif
++
++  memoized.store(address, std::memory_order_relaxed);
++  return reinterpret_cast<const unsigned char*>(address);
++}
++#endif  // __linux__
++
++// Compute the size of a stack frame in [low..high).  We assume that
++// low < high.  Return size of kUnknownFrameSize.
++template<typename T>
++static inline uintptr_t ComputeStackFrameSize(const T* low,
++                                              const T* high) {
++  const char* low_char_ptr = reinterpret_cast<const char *>(low);
++  const char* high_char_ptr = reinterpret_cast<const char *>(high);
++  return low < high ? high_char_ptr - low_char_ptr : kUnknownFrameSize;
++}
++
++// Given a pointer to a stack frame, locate and return the calling
++// stackframe, or return null if no stackframe can be found. Perform sanity
++// checks (the strictness of which is controlled by the boolean parameter
++// "STRICT_UNWINDING") to reduce the chance that a bad pointer is returned.
++template<bool STRICT_UNWINDING, bool WITH_CONTEXT>
++ATTRIBUTE_NO_SANITIZE_ADDRESS  // May read random elements from stack.
++ATTRIBUTE_NO_SANITIZE_MEMORY   // May read random elements from stack.
++static void **NextStackFrame(void **old_frame_pointer, const void *uc) {
++  void **new_frame_pointer = reinterpret_cast<void**>(*old_frame_pointer);
++  bool check_frame_size = true;
++
++#if defined(__linux__)
++  if (WITH_CONTEXT && uc != nullptr) {
++    // Check to see if next frame's return address is __kernel_rt_sigreturn.
++    if (old_frame_pointer[1] == GetKernelRtSigreturnAddress()) {
++      const ucontext_t *ucv = static_cast<const ucontext_t *>(uc);
++      // old_frame_pointer[0] is not suitable for unwinding, look at
++      // ucontext to discover frame pointer before signal.
++      void **const pre_signal_frame_pointer =
++          reinterpret_cast<void **>(ucv->uc_mcontext.regs[29]);
++
++      // Alleged frame pointer is readable, use it for further unwinding.
++      new_frame_pointer = pre_signal_frame_pointer;
++
++      // Skip frame size check if we return from a signal. We may be using a
++      // an alternate stack for signals.
++      check_frame_size = false;
++    }
++  }
++#endif
++
++  // aarch64 ABI requires stack pointer to be 16-byte-aligned.
++  if ((reinterpret_cast<uintptr_t>(new_frame_pointer) & 15) != 0)
++    return nullptr;
++
++  // Check frame size.  In strict mode, we assume frames to be under
++  // 100,000 bytes.  In non-strict mode, we relax the limit to 1MB.
++  if (check_frame_size) {
++    const uintptr_t max_size = STRICT_UNWINDING ? 100000 : 1000000;
++    const uintptr_t frame_size =
++        ComputeStackFrameSize(old_frame_pointer, new_frame_pointer);
++    if (frame_size == kUnknownFrameSize || frame_size > max_size)
++      return nullptr;
++  }
++
++  return new_frame_pointer;
++}
++#endif
++
++static int GET_STACK_TRACE_OR_FRAMES {
++#ifdef __GNUC__
++  void **frame_pointer = reinterpret_cast<void**>(__builtin_frame_address(0));
++#else
++# error reading stack point not yet supported on this platform.
++#endif
++
++  skip_count++;    // Skip the frame for this function.
++  int n = 0;
++
++  // The frame pointer points to low address of a frame.  The first 64-bit
++  // word of a frame points to the next frame up the call chain, which normally
++  // is just after the high address of the current frame.  The second word of
++  // a frame contains return adress of to the caller.   To find a pc value
++  // associated with the current frame, we need to go down a level in the call
++  // chain.  So we remember return the address of the last frame seen.  This
++  // does not work for the first stack frame, which belongs to UnwindImp() but
++  // we skip the frame for UnwindImp() anyway.
++  void* prev_return_address = nullptr;
++
++  while (frame_pointer && n < max_depth) {
++    // The absl::GetStackFrames routine is called when we are in some
++    // informational context (the failure signal handler for example).
++    // Use the non-strict unwinding rules to produce a stack trace
++    // that is as complete as possible (even if it contains a few bogus
++    // entries in some rare cases).
++#if IS_WITH_CONTEXT
++    void **next_frame_pointer =
++        NextStackFrame<!IS_STACK_FRAMES, IS_WITH_CONTEXT>(frame_pointer, ucp);
++#else
++    void **next_frame_pointer =
++        NextStackFrame<!IS_STACK_FRAMES, IS_WITH_CONTEXT>(frame_pointer, NULL);
++#endif
++    if (skip_count > 0) {
++      skip_count--;
++    } else {
++      result[n] = prev_return_address;
++#if IS_STACK_FRAMES
++        sizes[n] = ComputeStackFrameSize(frame_pointer, next_frame_pointer);
++#endif
++      n++;
++    }
++    prev_return_address = frame_pointer[1];
++    frame_pointer = next_frame_pointer;
++  }
++  return n;
++}
+-- 
+2.17.1
+


### PR DESCRIPTION
Add getting stacktrace implementation on aarch64 without using libunwind and gcc,
to solve this issue:  https://github.com/gperftools/gperftools/issues/1184 .
This is a reference implementation of :
https://github.com/abseil/abseil-cpp/blob/master/absl/debugging/internal/stacktrace_aarch64-inl.inc