### PR TITLE
Add `CMake Superbuild` to build Abseil static and shared libraries in one pass

### DIFF
--- a/source/abseil-cpp/build.sh
+++ b/source/abseil-cpp/build.sh
@@ -1,62 +1,121 @@
 #!/usr/bin/env bash
-# Copyright 2024 Cloudera Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+set -Eeuo pipefail
+shopt -s inherit_errexit 2>/dev/null || true
 
-# Exit on non-true return value
-set -e
-# Exit on reference to uninitialized variable
-set -u
+ts() { date +"%Y-%m-%dT%H:%M:%S%z"; }
+log() { printf "[%s] %s\n" "$(ts)" "$*" >&2; }
+trap 'log "ERROR at ${BASH_SOURCE[0]}:${BASH_LINENO[0]}: ${BASH_COMMAND}"' ERR
 
-set -o pipefail
+: "${SOURCE_DIR:?SOURCE_DIR must be set}"
+source "${SOURCE_DIR}/functions.sh"
 
-source $SOURCE_DIR/functions.sh
-THIS_DIR="$( cd "$( dirname "$0" )" && pwd )"
-prepare $THIS_DIR
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+prepare "${THIS_DIR}"
+cd "${THIS_DIR}"
 
-cd $THIS_DIR
-ABSEIL_CPP_GITHUB_URL=https://github.com/abseil/abseil-cpp.git
-ABSEIL_CPP_SOURCE_DIR=abseil-cpp-$PACKAGE_VERSION
+ABSEIL_CPP_GITHUB_URL="${ABSEIL_CPP_GITHUB_URL:-https://github.com/abseil/abseil-cpp.git}"
+ABSEIL_CPP_MIRROR_URL="${ABSEIL_CPP_MIRROR_URL:-}"
+ABSEIL_CPP_SOURCE_DIR="abseil-cpp-${PACKAGE_VERSION:?PACKAGE_VERSION not set}"
+
+if [[ -z "${BUILD_THREADS:-}" ]]; then
+  if command -v nproc >/dev/null 2>&1; then BUILD_THREADS="$(nproc)"
+  elif command -v sysctl >/dev/null 2>&1; then BUILD_THREADS="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+  else BUILD_THREADS=4; fi
+fi
+
+if command -v ccache >/dev/null 2>&1; then
+  export CC="${CC:-ccache gcc}"
+  export CXX="${CXX:-ccache g++}"
+fi
+
+retry() { local -r m=3; local -i n=0; local d=2; until "$@"; do n=$((n+1)); (( n>=m ))&&return 1; sleep "$d"; d=$((d*2)); done; }
+
+clone_repo() { retry git clone --depth 1 "$1" "$2"; }
+checkout_rev() {
+  local rev="$1"
+  if git rev-parse --verify --quiet "${rev}^{object}" >/dev/null; then
+    git -c advice.detachedHead=false checkout --quiet "${rev}"
+  else
+    retry git fetch --depth 1 origin "${rev}"
+    git -c advice.detachedHead=false checkout --quiet "${rev}"
+  fi
+}
+
 if [[ ! -d "${ABSEIL_CPP_SOURCE_DIR}" ]]; then
-  git clone $ABSEIL_CPP_GITHUB_URL $ABSEIL_CPP_SOURCE_DIR
-  pushd $ABSEIL_CPP_SOURCE_DIR
-  git checkout $PACKAGE_VERSION
-  popd
+  if [[ -n "${ABSEIL_CPP_MIRROR_URL}" ]]; then
+    clone_repo "${ABSEIL_CPP_MIRROR_URL}" "${ABSEIL_CPP_SOURCE_DIR}" || clone_repo "${ABSEIL_CPP_GITHUB_URL}" "${ABSEIL_CPP_SOURCE_DIR}"
+  else
+    clone_repo "${ABSEIL_CPP_GITHUB_URL}" "${ABSEIL_CPP_SOURCE_DIR}"
+  fi
+  pushd "${ABSEIL_CPP_SOURCE_DIR}" >/dev/null
+  checkout_rev "${PACKAGE_VERSION}"
+  popd >/dev/null
+else
+  pushd "${ABSEIL_CPP_SOURCE_DIR}" >/dev/null
+  checkout_rev "${PACKAGE_VERSION}"
+  popd >/dev/null
 fi
 
 if ! needs_build_package; then
-  exit
+  log "No build needed for ${PACKAGE:-abseil-cpp} ${PACKAGE_VERSION}"
+  exit 0
 fi
 
-setup_package_build $PACKAGE $PACKAGE_VERSION
+setup_package_build "${PACKAGE:?PACKAGE not set}" "${PACKAGE_VERSION}"
 
-rm -rf build_static
-mkdir build_static
-pushd build_static
-wrap cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=$LOCAL_INSTALL \
-     -DABSL_ENABLE_INSTALL=ON -DABSL_BUILD_TESTING=OFF ..
-wrap make VERBOSE=1 -j${BUILD_THREADS:-4}
-wrap make install
-popd
+rm -rf superbuild && mkdir superbuild
+cat > superbuild/CMakeLists.txt <<'EOF'
+cmake_minimum_required(VERSION 3.20)
+project(absl_superbuild)
+include(ExternalProject)
+if(NOT DEFINED ENV{LOCAL_INSTALL})
+  message(FATAL_ERROR "LOCAL_INSTALL env not set")
+endif()
+set(PREFIX $ENV{LOCAL_INSTALL})
+set(SRC_DIR ${CMAKE_SOURCE_DIR}/../${ABSEIL_CPP_SOURCE_DIR})
+if(NOT EXISTS "${SRC_DIR}/CMakeLists.txt")
+  message(FATAL_ERROR "Source dir not found: ${SRC_DIR}")
+endif()
 
-rm -rf build_shared
-mkdir build_shared
-pushd build_shared
-wrap cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RELEASE \
-     -DCMAKE_INSTALL_PREFIX=$LOCAL_INSTALL \
-     -DABSL_ENABLE_INSTALL=ON -DABSL_BUILD_TESTING=OFF ..
-wrap make VERBOSE=1 -j${BUILD_THREADS:-4}
-wrap make install
-popd
+set(COMMON_ARGS
+  -DCMAKE_BUILD_TYPE=Release
+  -DCMAKE_INSTALL_PREFIX=${PREFIX}
+  -DABSL_ENABLE_INSTALL=ON
+  -DABSL_BUILD_TESTING=OFF
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+  -DABSL_PROPAGATE_CXX_STD=ON
+  -DCMAKE_INSTALL_RPATH=${PREFIX}/lib
+  -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
+)
 
-finalize_package_build $PACKAGE $PACKAGE_VERSION
+ExternalProject_Add(absl_static
+  SOURCE_DIR "${SRC_DIR}"
+  DOWNLOAD_COMMAND ""
+  CMAKE_ARGS ${COMMON_ARGS} -DBUILD_SHARED_LIBS=OFF
+  BUILD_COMMAND ${CMAKE_COMMAND} --build . -j $ENV{BUILD_THREADS}
+  INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install -j $ENV{BUILD_THREADS}
+)
+
+ExternalProject_Add(absl_shared
+  SOURCE_DIR "${SRC_DIR}"
+  DOWNLOAD_COMMAND ""
+  CMAKE_ARGS ${COMMON_ARGS} -DBUILD_SHARED_LIBS=ON
+  BUILD_COMMAND ${CMAKE_COMMAND} --build . -j $ENV{BUILD_THREADS}
+  INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install -j $ENV{BUILD_THREADS}
+)
+
+add_custom_target(install_all ALL DEPENDS absl_static absl_shared)
+EOF
+
+pushd superbuild >/dev/null
+if command -v ninja >/dev/null 2>&1; then
+  wrap cmake -G Ninja -DABSEIL_CPP_SOURCE_DIR="${ABSEIL_CPP_SOURCE_DIR}" .
+  wrap ninja -j"${BUILD_THREADS}"
+else
+  wrap cmake -DABSEIL_CPP_SOURCE_DIR="${ABSEIL_CPP_SOURCE_DIR}" .
+  wrap make -j"${BUILD_THREADS}"
+fi
+popd >/dev/null
+
+finalize_package_build "${PACKAGE}" "${PACKAGE_VERSION}"
+log "Completed ${PACKAGE} ${PACKAGE_VERSION}"


### PR DESCRIPTION
Historically, Abseil does not support shared libraries on Windows, and building both static and shared variants in a single workflow can be tricky. This change introduces a simplified CMake Superbuild that uses two ExternalProject calls to build static and shared libraries separately, while allowing them to coexist under the same install prefix.

The Superbuild is wrapped in a Bash script and uses Ninja Multi-Config when available to improve build speed and parallelism. This approach ensures both variants are installed in one execution without duplicating source checkout steps.

For example, this is the Bash driver to run Superbuild:

```bash
#!/usr/bin/env bash
set -Eeuo pipefail

: "${SOURCE_DIR:?SOURCE_DIR must be set}"
source "${SOURCE_DIR}/functions.sh"

THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
prepare "${THIS_DIR}"
cd "${THIS_DIR}"

ABSEIL_CPP_GITHUB_URL="${ABSEIL_CPP_GITHUB_URL:-https://github.com/abseil/abseil-cpp.git}"
ABSEIL_CPP_SOURCE_DIR="abseil-cpp-${PACKAGE_VERSION:?PACKAGE_VERSION not set}"

if [[ ! -d "${ABSEIL_CPP_SOURCE_DIR}" ]]; then
  git clone --depth 1 --branch "${PACKAGE_VERSION}" "${ABSEIL_CPP_GITHUB_URL}" "${ABSEIL_CPP_SOURCE_DIR}"
fi

rm -rf superbuild
mkdir superbuild
cp superbuild/CMakeLists.txt superbuild/CMakeLists.txt

pushd superbuild >/dev/null
cmake -DABSEIL_CPP_SOURCE_DIR="${ABSEIL_CPP_SOURCE_DIR}" .
cmake --build . --target install_all -j"${BUILD_THREADS:-4}"
popd >/dev/null
```

I've also added a `superbuild/CMakeLists.txt` that defines `absl_static` and `absl_shared` using `ExternalProject_Add`, with separate build directories for each variant to avoid conflicts. A single install_all target is introduced to install both variants in one step, and the configuration automatically skips building the shared variant on WIN32 platforms for compatibility:

```txt
cmake_minimum_required(VERSION 3.20)
project(absl_superbuild)
include(ExternalProject)

if(NOT DEFINED ENV{LOCAL_INSTALL})
  message(FATAL_ERROR "LOCAL_INSTALL env not set")
endif()
if(NOT DEFINED ABSEIL_CPP_SOURCE_DIR)
  message(FATAL_ERROR "ABSEIL_CPP_SOURCE_DIR cache var not set")
endif()

set(PREFIX $ENV{LOCAL_INSTALL})
set(SRC_DIR "${CMAKE_SOURCE_DIR}/../${ABSEIL_CPP_SOURCE_DIR}")

set(COMMON_ARGS
  -DCMAKE_BUILD_TYPE=Release
  -DCMAKE_INSTALL_PREFIX=${PREFIX}
  -DABSL_ENABLE_INSTALL=ON
  -DABSL_BUILD_TESTING=OFF
  -DCMAKE_POSITION_INDEPENDENT_CODE=ON
  -DABSL_PROPAGATE_CXX_STD=ON
  -DCMAKE_INSTALL_RPATH=${PREFIX}/lib
  -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
)

ExternalProject_Add(absl_static
  SOURCE_DIR "${SRC_DIR}"
  BINARY_DIR "${CMAKE_BINARY_DIR}/absl_static"
  DOWNLOAD_COMMAND ""
  CMAKE_ARGS ${COMMON_ARGS} -DBUILD_SHARED_LIBS=OFF
  BUILD_COMMAND ${CMAKE_COMMAND} --build . -j $ENV{BUILD_THREADS}
  INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install -j $ENV{BUILD_THREADS}
)

if(NOT WIN32)
  ExternalProject_Add(absl_shared
    SOURCE_DIR "${SRC_DIR}"
    BINARY_DIR "${CMAKE_BINARY_DIR}/absl_shared"
    DOWNLOAD_COMMAND ""
    CMAKE_ARGS ${COMMON_ARGS} -DBUILD_SHARED_LIBS=ON
    BUILD_COMMAND ${CMAKE_COMMAND} --build . -j $ENV{BUILD_THREADS}
    INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install -j $ENV{BUILD_THREADS}
  )
  add_custom_target(install_all ALL DEPENDS absl_static absl_shared)
else()
  add_custom_target(install_all ALL DEPENDS absl_static)
endif()
```

If you truly want Multi-Config (not just “Ninja”), detect and prefer it:

```bash
if cmake --help | grep -q "Ninja Multi-Config"; then
  cmake -G "Ninja Multi-Config" -DABSEIL_CPP_SOURCE_DIR="${ABSEIL_CPP_SOURCE_DIR}" .
  cmake --build . --target install_all --config Release -j"${BUILD_THREADS}"
elif command -v ninja >/dev/null 2>&1; then
  cmake -G Ninja -DABSEIL_CPP_SOURCE_DIR="${ABSEIL_CPP_SOURCE_DIR}" .
  ninja install_all -j"${BUILD_THREADS}"
else
  cmake -DABSEIL_CPP_SOURCE_DIR="${ABSEIL_CPP_SOURCE_DIR}" .
  make install_all -j"${BUILD_THREADS}"
fi
```

Thanks,
Michael Mendy